### PR TITLE
Log provided public keys during server initialization

### DIFF
--- a/prover/src/server.rs
+++ b/prover/src/server.rs
@@ -39,6 +39,8 @@ pub async fn start(args: Args) -> Result<(), ServerError> {
         .with(tracing_subscriber::fmt::layer())
         .init();
 
+    let keys = args.authorized_keys.clone().unwrap_or_default();
+
     let authorizer = match args.authorized_keys_path {
         Some(path) => {
             tracing::trace!("Using authorized keys file");
@@ -80,6 +82,7 @@ pub async fn start(args: Args) -> Result<(), ServerError> {
 
     let address: SocketAddr = format!("{}:{}", args.host, args.port).parse()?;
     tracing::trace!("start listening on {}", address);
+    tracing::trace!("provided public keys {:?}", keys);
 
     // Create a `TcpListener` using tokio.
     let listener = TcpListener::bind(address).await?;


### PR DESCRIPTION
A clone of the provided authorized keys is logged at the server start. This helps in debugging by ensuring that the server initialization logs include all provided public keys.