### PR TITLE
Add health check route

### DIFF
--- a/prover/src/server.rs
+++ b/prover/src/server.rs
@@ -74,7 +74,14 @@ pub async fn start(args: Args) -> Result<(), ProverError> {
         sse_tx: Arc::new(Mutex::new(sse_tx)),
     };
 
+    async fn ok_handler() -> &'static str {
+        "OK"
+    }
+
+    let ok_router = Router::new().route("/", axum::routing::get(ok_handler));
+
     let app = Router::new()
+        .nest("/", ok_router)
         .route("/verify", post(root))
         .route("/get-job/:id", get(get_job))
         .route("/sse", get(sse_handler))

--- a/prover/src/server.rs
+++ b/prover/src/server.rs
@@ -78,10 +78,8 @@ pub async fn start(args: Args) -> Result<(), ProverError> {
         "OK"
     }
 
-    let ok_router = Router::new().route("/", axum::routing::get(ok_handler));
-
     let app = Router::new()
-        .nest("/", ok_router)
+        .route("/", get(ok_handler))
         .route("/verify", post(root))
         .route("/get-job/:id", get(get_job))
         .route("/sse", get(sse_handler))


### PR DESCRIPTION
Introduced an `ok_handler` and nested it under the root path for a simple health check endpoint. This helps in monitoring the server status with a straightforward "OK" response.