### PR TITLE
Add rust-cache action to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,8 @@ jobs:
 
       - uses: actions/checkout@v4
 
+      - uses: Swatinem/rust-cache@v2
+
       - name: Run tests
         run: ./scripts/e2e_test.sh
 


### PR DESCRIPTION
Incorporated Swatinem/rust-cache@v2 to optimize the CI process by caching Rust dependencies. This change aims to speed up build times and improve overall CI efficiency.