### PR TITLE
Log public keys during server startup

### DIFF
--- a/prover/src/server.rs
+++ b/prover/src/server.rs
@@ -96,6 +96,9 @@ pub async fn start(args: Args) -> Result<(), ProverError> {
 
     trace!("Listening on {}", address);
 
+    let keys = args.authorized_keys.clone();
+    trace!("provided public keys {:?}", keys);
+
     serve(listener, app)
         .with_graceful_shutdown(shutdown_signal(app_state.thread_pool))
         .await?;


### PR DESCRIPTION
Added a trace log to capture and display provided public keys during the server's startup process. This is intended to assist in debugging and verifying that the correct public keys are being loaded.