### PR TITLE
fix(prover-sdk): add missing derive and reexpose common types used by sdk API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -480,17 +480,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crypto-bigint"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
-dependencies = [
- "generic-array",
- "subtle",
- "zeroize",
-]
-
-[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -596,7 +585,6 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
- "subtle",
 ]
 
 [[package]]
@@ -873,15 +861,6 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
-name = "hmac"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
-dependencies = [
- "digest",
-]
 
 [[package]]
 name = "http"
@@ -1695,16 +1674,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rfc6979"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
-dependencies = [
- "hmac",
- "subtle",
-]
-
-[[package]]
 name = "ring"
 version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2023,19 +1992,15 @@ dependencies = [
 [[package]]
 name = "starknet-types-core"
 version = "0.1.5"
-source = "git+https://github.com/neotheprogramist/types-rs.git?branch=fix/2-types#ad226a91c21b74c63c920216caa8df0a7bff64cb"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6bacf0ba19bc721e518bc4bf389ff13daa8a7c5db5fd320600473b8aa9fcbd"
 dependencies = [
- "crypto-bigint",
- "hmac",
  "lambdaworks-crypto",
  "lambdaworks-math",
  "num-bigint",
  "num-integer",
  "num-traits",
- "rfc6979",
  "serde",
- "sha2",
- "zeroize",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,6 @@ rand = "0.8.5"
 ed25519-dalek = { version = "2.1.1", features = ["rand_core", "serde"] }
 chrono = "0.4.38"
 base64 = "0.22.1"
-starknet-types-core = { git = "https://github.com/neotheprogramist/types-rs.git", branch = "fix/2-types" }
+starknet-types-core = "~0.1.4"
 futures = "0.3.30"
 async-stream = "0.3.5"

--- a/prover-sdk/src/access_key.rs
+++ b/prover-sdk/src/access_key.rs
@@ -2,7 +2,7 @@ use ed25519_dalek::SigningKey;
 
 use crate::errors::SdkErrors;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Eq, PartialEq, Clone, serde::Serialize, serde::Deserialize)]
 pub struct ProverAccessKey(pub SigningKey);
 
 impl ProverAccessKey {

--- a/prover-sdk/src/lib.rs
+++ b/prover-sdk/src/lib.rs
@@ -2,3 +2,6 @@ pub mod access_key;
 pub mod errors;
 pub mod sdk;
 pub mod sdk_builder;
+
+pub use common::cairo0_prover_input::Cairo0ProverInput;
+pub use common::cairo_prover_input::CairoProverInput;


### PR DESCRIPTION
Some derives were missing for Saya, and re-expose the common types used around the prover SDK to avoid having to import `common`.

We may rename `common` to `prover-common` to be imported by Saya in the future if it's growing with more types.
