### PR TITLE
Piniom/3 Fix the `JobStore`

### DIFF
--- a/prover/src/utils/config.rs
+++ b/prover/src/utils/config.rs
@@ -87,7 +87,7 @@ struct ProgramPublicInputAsNSteps {
 
 impl ProgramPublicInputAsNSteps {
     pub fn read_from_file(input_file: &PathBuf) -> Result<Self, ProverError> {
-        serde_json::from_reader(BufReader::new(File::open(&input_file)?)).map_err(ProverError::from)
+        serde_json::from_reader(BufReader::new(File::open(input_file)?)).map_err(ProverError::from)
     }
     fn calculate_fri_step_list(&self, degree_bound: u32) -> Vec<u32> {
         let fri_degree = ((self.n_steps as f64 / degree_bound as f64).log(2.0).round() as u32) + 4;

--- a/prover/src/utils/job.rs
+++ b/prover/src/utils/job.rs
@@ -6,16 +6,21 @@ use axum::{
 };
 use common::models::JobStatus;
 use serde::Serialize;
-use std::sync::Arc;
+use std::{
+    collections::BTreeMap,
+    sync::Arc,
+    time::{Duration, Instant},
+};
 use tokio::sync::Mutex;
 
 use crate::{auth::jwt::Claims, server::AppState};
 
-#[derive(Serialize, Clone)]
+#[derive(Clone)]
 pub struct Job {
     pub id: u64,
     pub status: JobStatus,
     pub result: Option<String>,
+    pub created: Instant,
 }
 
 #[derive(Serialize)]
@@ -26,34 +31,73 @@ pub enum JobResponse {
     Failed { error: String },
 }
 
-#[derive(Clone, Default)]
+#[derive(Default, Clone)]
 pub struct JobStore {
-    jobs: Arc<Mutex<Vec<Job>>>,
+    inner: Arc<Mutex<JobStoreInner>>,
 }
 
 impl JobStore {
     pub async fn create_job(&self) -> u64 {
-        let mut jobs = self.jobs.lock().await;
-        let job_id = jobs.len() as u64;
+        let id = self.inner.lock().await.create_job();
+        id
+    }
+    pub async fn update_job_status(&self, job_id: u64, status: JobStatus, result: Option<String>) {
+        self.inner
+            .lock()
+            .await
+            .update_job_status(job_id, status, result)
+    }
+    pub async fn get_job(&self, id: u64) -> Option<Job> {
+        self.inner.lock().await.get_job(id)
+    }
+}
+
+#[derive(Default)]
+struct JobStoreInner {
+    jobs: BTreeMap<u64, Job>,
+    counter: u64,
+}
+
+impl JobStoreInner {
+    pub fn create_job(&mut self) -> u64 {
+        let job_id = self.counter;
+        self.counter += 1;
         let new_job = Job {
             id: job_id,
             status: JobStatus::Pending,
             result: None,
+            created: Instant::now(),
         };
-        jobs.push(new_job);
-        drop(jobs);
+        self.jobs.insert(job_id, new_job);
+        self.clear_old_jobs();
         job_id
     }
-    pub async fn update_job_status(&self, job_id: u64, status: JobStatus, result: Option<String>) {
-        let mut jobs = self.jobs.lock().await;
-        if let Some(job) = jobs.iter_mut().find(|job| job.id == job_id) {
+    pub fn update_job_status(&mut self, job_id: u64, status: JobStatus, result: Option<String>) {
+        if let Some(job) = self.jobs.get_mut(&job_id) {
             job.status = status;
             job.result = result;
         }
+        self.clear_old_jobs()
     }
-    pub async fn get_job(&self, id: u64) -> Option<Job> {
-        let jobs = self.jobs.lock().await;
-        jobs.iter().find(|job| job.id == id).cloned()
+    pub fn get_job(&mut self, id: u64) -> Option<Job> {
+        let job = self.jobs.get(&id).cloned();
+        self.clear_old_jobs();
+        job
+    }
+    // Clear old jobs so that the memory doesn't go balistic if the server runs for a long time
+    fn clear_old_jobs(&mut self) {
+        let expiry_duration = Duration::from_secs(5 * 60 * 60); // 5 hours
+        loop {
+            match self.jobs.pop_first() {
+                Some((id, job)) => {
+                    if job.created.elapsed() < expiry_duration {
+                        self.jobs.insert(id, job);
+                        break;
+                    }
+                }
+                None => break,
+            }
+        }
     }
 }
 


### PR DESCRIPTION
This PR solves 3 minor problems:
- Cargo fmt and clippy from previous PRs :)))
- Improved job lookup efficiency 
- Fixed memory bloat when the server runs for a long time (Jobs older than 5 hours are lazily removed from the memory)
