### PR TITLE
Fix/sdk format

### DIFF
--- a/bin/cairo-prove/src/fetch.rs
+++ b/bin/cairo-prove/src/fetch.rs
@@ -1,24 +1,19 @@
 use std::time::Duration;
 
 use prover_sdk::sdk::ProverSDK;
-use serde::Deserialize;
 use serde_json::Value;
 use tokio::time::sleep;
 use tracing::info;
 
 use crate::errors::ProveErrors;
 
-#[derive(Deserialize)]
-pub struct JobId {
-    pub job_id: u64,
-}
 
-pub async fn fetch_job_sse(sdk: ProverSDK, job: String) -> Result<String, ProveErrors> {
-    let job: JobId = serde_json::from_str(&job)?;
-    info!("Job ID: {}", job.job_id);
-    sdk.sse(job.job_id).await?;
+
+pub async fn fetch_job_sse(sdk: ProverSDK, job: u64) -> Result<String, ProveErrors> {
+    info!("Job ID: {}", job);
+    sdk.sse(job).await?;
     info!("Job completed");
-    let response = sdk.get_job(job.job_id).await?;
+    let response = sdk.get_job(job).await?;
     let response = response.text().await?;
     let json_response: Value = serde_json::from_str(&response)?;
     if let Some(status) = json_response.get("status").and_then(Value::as_str) {
@@ -35,12 +30,11 @@ pub async fn fetch_job_sse(sdk: ProverSDK, job: String) -> Result<String, ProveE
         Err(ProveErrors::Custom(json_response.to_string()))
     }
 }
-pub async fn fetch_job_polling(sdk: ProverSDK, job: String) -> Result<String, ProveErrors> {
-    let job: JobId = serde_json::from_str(&job)?;
-    info!("Fetching job: {}", job.job_id);
+pub async fn fetch_job_polling(sdk: ProverSDK, job: u64) -> Result<String, ProveErrors> {
+    info!("Fetching job: {}", job);
     let mut counter = 0;
     loop {
-        let response = sdk.get_job(job.job_id).await?;
+        let response = sdk.get_job(job).await?;
         let response = response.text().await?;
         let json_response: Value = serde_json::from_str(&response)?;
         if let Some(status) = json_response.get("status").and_then(Value::as_str) {

--- a/bin/cairo-prove/src/fetch.rs
+++ b/bin/cairo-prove/src/fetch.rs
@@ -7,8 +7,6 @@ use tracing::info;
 
 use crate::errors::ProveErrors;
 
-
-
 pub async fn fetch_job_sse(sdk: ProverSDK, job: u64) -> Result<String, ProveErrors> {
     info!("Job ID: {}", job);
     sdk.sse(job).await?;

--- a/bin/cairo-prove/src/prove.rs
+++ b/bin/cairo-prove/src/prove.rs
@@ -9,7 +9,7 @@ use common::{
 use prover_sdk::sdk::ProverSDK;
 use serde_json::Value;
 
-pub async fn prove(args: Args, sdk: ProverSDK) -> Result<String, ProveErrors> {
+pub async fn prove(args: Args, sdk: ProverSDK) -> Result<u64, ProveErrors> {
     let program = std::fs::read_to_string(&args.program_path)?;
     let proof = match args.cairo_version {
         CairoVersion::V0 => {

--- a/prover-sdk/src/errors.rs
+++ b/prover-sdk/src/errors.rs
@@ -30,6 +30,8 @@ pub enum SdkErrors {
     RegisterResponseError(String),
     #[error("SSE error: {0}")]
     SSEError(String),
+    #[error("Verify response error: {0}")]
+    VerifyResponseError(String),
     #[error("Invalid key")]
     InvalidKey,
 }

--- a/prover-sdk/tests/helpers/mod.rs
+++ b/prover-sdk/tests/helpers/mod.rs
@@ -1,16 +1,10 @@
 use prover_sdk::sdk::ProverSDK;
-use serde::Deserialize;
 use serde_json::Value;
 
-#[derive(Deserialize)]
-pub struct JobId {
-    pub job_id: u64,
-}
-pub async fn fetch_job(sdk: ProverSDK, job: String) -> String {
-    let job: JobId = serde_json::from_str(&job).unwrap();
-    println!("Job ID: {}", job.job_id);
-    sdk.sse(job.job_id).await.unwrap();
-    let response = sdk.get_job(job.job_id).await.unwrap();
+pub async fn fetch_job(sdk: ProverSDK, job: u64) -> String {
+    println!("Job ID: {}", job);
+    sdk.sse(job).await.unwrap();
+    let response = sdk.get_job(job).await.unwrap();
     let response = response.text().await.unwrap();
     let json_response: Value = serde_json::from_str(&response).unwrap();
     return json_response

--- a/prover/src/threadpool/run.rs
+++ b/prover/src/threadpool/run.rs
@@ -39,6 +39,7 @@ impl CairoVersionedInput {
     async fn run(&self, paths: &RunPaths<'_>) -> Result<(), ProverError> {
         match self {
             CairoVersionedInput::Cairo(input) => {
+                trace!("Running cairo1-run");
                 let command = paths.cairo1_run_command(&input.layout);
                 command_run(command).await
             }

--- a/scripts/e2e_test.sh
+++ b/scripts/e2e_test.sh
@@ -1,22 +1,23 @@
-# !/usr/bin/env bash
+#!/usr/bin/env bash
 
 set -eux
 IMAGE_NAME="http-prover-test"
-# Check if the image already exists
+CONTAINER_ENGINE="${CONTAINER_ENGINE:-docker}"
 
-if docker images | grep -q "$IMAGE_NAME"; then
+# Check if the image already exists
+if $CONTAINER_ENGINE images | grep -q "$IMAGE_NAME"; then
     echo "Image $IMAGE_NAME already exists. Skipping build step."
 else
     echo "Image $IMAGE_NAME does not exist. Building the image..."
 
     if [ "${CI:-}" == "true" ]; then
-        docker buildx build -t $IMAGE_NAME . \
+        $CONTAINER_ENGINE buildx build -t $IMAGE_NAME . \
             --cache-from type=local,src=/tmp/.buildx-cache \
             --cache-to type=local,dest=/tmp/.buildx-cache-new,mode=max \
-            --output=type=docker,dest=image.tar
-        docker load -i image.tar
+            --output=type=$CONTAINER_ENGINE,dest=image.tar
+        $CONTAINER_ENGINE load -i image.tar
     else
-        docker build -t $IMAGE_NAME .
+        $CONTAINER_ENGINE build -t $IMAGE_NAME .
     fi
 
     if [ $? -ne 0 ]; then
@@ -35,7 +36,11 @@ KEYGEN_OUTPUT=$(cargo run -p keygen)
 ADMIN_PUBLIC_KEY=$(echo "$KEYGEN_OUTPUT" | grep "Public key" | awk '{print $3}' | tr -d ',' | tr -d '[:space:]')
 ADMIN_PRIVATE_KEY=$(echo "$KEYGEN_OUTPUT" | grep "Private key" | awk '{print $3}' | tr -d ',' | tr -d '[:space:]')
 
-docker run -d --name http_prover_test \
+REPLACE_FLAG=""
+if [ "$CONTAINER_ENGINE" == "podman" ]; then
+    REPLACE_FLAG="--replace"
+fi
+$CONTAINER_ENGINE run -d --name http_prover_test $REPLACE_FLAG \
     -p 3040:3000 $IMAGE_NAME \
     --jwt-secret-key "secret" \
     --message-expiration-time 3600 \
@@ -45,5 +50,5 @@ docker run -d --name http_prover_test \
 
 PRIVATE_KEY=$PRIVATE_KEY PROVER_URL="http://localhost:3040" ADMIN_PRIVATE_KEY=$ADMIN_PRIVATE_KEY cargo test --no-fail-fast --workspace --verbose
 
-docker stop http_prover_test
-docker rm http_prover_test
+$CONTAINER_ENGINE stop http_prover_test
+$CONTAINER_ENGINE rm http_prover_test


### PR DESCRIPTION
This PR is adding a functionality to change container engine to podman/docker by setting env, as default its docker.
Sdk now returns job_id as u64 instead of serialized struct with it. 