### PR TITLE
Enable Docker build caching in GitHub Actions workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -57,6 +57,8 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Added cache-from and cache-to directives to the Docker build step in the publish.yml workflow. This change aims to speed up build times by leveraging local caching.