### PR TITLE
Rename `admins_keys` to `admin_keys` across the codebase

### DIFF
--- a/prover/src/auth/register.rs
+++ b/prover/src/auth/register.rs
@@ -10,7 +10,7 @@ pub async fn register(
     _claims: Claims,
     Json(payload): Json<AddKeyRequest>,
 ) -> Result<impl IntoResponse, ProverError> {
-    if !state.admins_keys.contains(&payload.authority) {
+    if !state.admin_keys.contains(&payload.authority) {
         return Err(ProverError::Auth(AuthError::Unauthorized));
     }
     payload

--- a/prover/src/auth/validation.rs
+++ b/prover/src/auth/validation.rs
@@ -119,7 +119,7 @@ mod tests {
             thread_pool: Arc::new(Mutex::new(ThreadPool::new(1))),
             nonces,
             authorizer: Authorizer::Open,
-            admins_keys: vec![generate_verifying_key(&generate_signing_key())],
+            admin_keys: vec![generate_verifying_key(&generate_signing_key())],
             sse_tx: Arc::new(Mutex::new(tokio::sync::broadcast::channel(100).0)),
         };
 
@@ -162,7 +162,7 @@ mod tests {
             thread_pool: Arc::new(Mutex::new(ThreadPool::new(1))),
             nonces,
             authorizer: Authorizer::Open,
-            admins_keys: vec![generate_verifying_key(&generate_signing_key())],
+            admin_keys: vec![generate_verifying_key(&generate_signing_key())],
             sse_tx: Arc::new(Mutex::new(tokio::sync::broadcast::channel(100).0)),
         };
 
@@ -202,7 +202,7 @@ mod tests {
             thread_pool: Arc::new(Mutex::new(ThreadPool::new(1))),
             nonces,
             authorizer: Authorizer::Open,
-            admins_keys: vec![generate_verifying_key(&generate_signing_key())],
+            admin_keys: vec![generate_verifying_key(&generate_signing_key())],
             sse_tx: Arc::new(Mutex::new(tokio::sync::broadcast::channel(100).0)),
         };
 
@@ -243,7 +243,7 @@ mod tests {
             thread_pool: Arc::new(Mutex::new(ThreadPool::new(1))),
             nonces,
             authorizer: Authorizer::Open,
-            admins_keys: vec![generate_verifying_key(&generate_signing_key())],
+            admin_keys: vec![generate_verifying_key(&generate_signing_key())],
             sse_tx: Arc::new(Mutex::new(tokio::sync::broadcast::channel(100).0)),
         };
 

--- a/prover/src/lib.rs
+++ b/prover/src/lib.rs
@@ -31,5 +31,5 @@ pub struct Args {
     #[arg(long, env, default_value = "4")]
     pub num_workers: usize,
     #[arg(long, env, value_delimiter = ',')]
-    pub admins_keys: Vec<String>,
+    pub admin_keys: Vec<String>,
 }

--- a/prover/src/server.rs
+++ b/prover/src/server.rs
@@ -34,7 +34,7 @@ pub struct AppState {
     pub jwt_secret_key: String,
     pub nonces: Arc<Mutex<HashMap<NonceString, VerifyingKey>>>,
     pub authorizer: Authorizer,
-    pub admins_keys: Vec<VerifyingKey>,
+    pub admin_keys: Vec<VerifyingKey>,
     pub sse_tx: Arc<Mutex<Sender<String>>>,
 }
 
@@ -49,12 +49,12 @@ pub async fn start(args: Args) -> Result<(), ProverError> {
 
     let authorizer =
         Authorizer::Persistent(FileAuthorizer::new(args.authorized_keys_path.clone()).await?);
-    let mut admins_keys = Vec::new();
-    for key in args.admins_keys {
+    let mut admin_keys = Vec::new();
+    for key in args.admin_keys {
         let verifying_key_bytes = prefix_hex::decode::<Vec<u8>>(key)
             .map_err(|e| AuthorizerError::PrefixHexConversionError(e.to_string()))?;
         let verifying_key = VerifyingKey::from_bytes(&verifying_key_bytes.try_into()?)?;
-        admins_keys.push(verifying_key);
+        admin_keys.push(verifying_key);
         authorizer.authorize(verifying_key).await?;
     }
 
@@ -73,7 +73,7 @@ pub async fn start(args: Args) -> Result<(), ProverError> {
         authorizer,
         job_store: JobStore::default(),
         thread_pool: Arc::new(Mutex::new(ThreadPool::new(args.num_workers))),
-        admins_keys,
+        admin_keys,
         sse_tx: Arc::new(Mutex::new(sse_tx)),
     };
 

--- a/scripts/e2e_test.sh
+++ b/scripts/e2e_test.sh
@@ -50,8 +50,8 @@ $CONTAINER_ENGINE run -d --name http_prover_test $REPLACE_FLAG \
     --message-expiration-time 3600 \
     --session-expiration-time 3600 \
     --authorized-keys $PUBLIC_KEY,$ADMIN_PUBLIC_KEY1,$ADMIN_PUBLIC_KEY2 \
-    --admins-keys $ADMIN_PUBLIC_KEY1,$ADMIN_PUBLIC_KEY2 
-    
+    --admin-keys $ADMIN_PUBLIC_KEY1,$ADMIN_PUBLIC_KEY2
+
 start_time=$(date +%s)
 
 PRIVATE_KEY=$PRIVATE_KEY PROVER_URL="http://localhost:3040" ADMIN_PRIVATE_KEY_1=$ADMIN_PRIVATE_KEY1 ADMIN_PRIVATE_KEY_2=$ADMIN_PRIVATE_KEY2 cargo test --no-fail-fast --workspace --verbose


### PR DESCRIPTION
Standardize the naming convention by renaming `admins_keys` to `admin_keys` in all relevant files. This change ensures consistency and eliminates potential confusion due to differing key names.