### PR TITLE
[BREAKING] removed input from proof output

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ WORKDIR /app
 COPY --from=planner /app/recipe.json recipe.json
 # Build dependencies - this is the caching Docker layer!
 RUN cargo chef cook --release --recipe-path recipe.json
-RUN cargo install --git https://github.com/lambdaclass/cairo-vm --rev d2c056e4a89aec9901c176f056dbcc58dd4660e5 cairo1-run
+RUN cargo install --git https://github.com/chudkowsky/cairo-vm.git --rev 6518777143224043c9dfad72c868843adb2c4145 cairo1-run
 RUN cargo build --release -p prover
 
 # Build application

--- a/k8s/prover.yaml
+++ b/k8s/prover.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: http-prover
-        image: docker.io/chudas/http-prover:v0.2
+        image: docker.io/chudas/http-prover:v0.4
         ports:
           - containerPort: 3000
         envFrom:

--- a/prover-sdk/tests/prove_test.rs
+++ b/prover-sdk/tests/prove_test.rs
@@ -36,7 +36,7 @@ async fn test_cairo_prove_bootloader() {
     assert!(result.is_some());
     let result = result.unwrap();
     // //Values calculated using https://github.com/HerodotusDev/integrity
-    assert_eq!(result.serialized_proof.len(), 3117);
+    assert_eq!(result.serialized_proof.len(), 3150);
     assert_eq!(
         result.program_hash,
         Felt::from_hex("0x59c0bac6bc951237009c9c51711516b8a06d7b18acc37d53563f6ad4014d978")
@@ -44,7 +44,7 @@ async fn test_cairo_prove_bootloader() {
     );
     assert_eq!(
         result.program_output_hash,
-        Felt::from_hex("0x7216da28237d9a39cbb472112b92178ecaf8440bba0edb0ad15bb1e93742a54")
+        Felt::from_hex("0x4750a6b33e72cdbfdf16e50b8399de348306ef213d3131868b570dbbc836fa8")
             .unwrap()
     );
     let result = sdk.clone().verify(result.proof).await;
@@ -80,15 +80,15 @@ async fn test_cairo_prove() {
     assert!(result.is_some());
     let result = result.unwrap();
     // //Values calculated using https://github.com/HerodotusDev/integrity
-    assert_eq!(result.serialized_proof.len(), 2469);
+    assert_eq!(result.serialized_proof.len(), 2425);
     assert_eq!(
         result.program_hash,
-        Felt::from_hex("0x4fa9237f64ebf68987209abe5058c32961131e3e5f16383d832dba7a6a5c937")
+        Felt::from_hex("0x107db7f77b9886a14ae24f828ba20ba44830d2947a2cade503c637a4e0babdb")
             .unwrap()
     );
     assert_eq!(
         result.program_output_hash,
-        Felt::from_hex("0x4dd3006138ea865d5610d65e02fd227b7436acc95e4b2ec30f5a21356ea6205")
+        Felt::from_hex("0x21085a88ad099f8cbe2038f73cb2934abcc380ace4b598e4b52be04eb184b2f")
             .unwrap()
     );
     let result = sdk.clone().verify(result.proof).await;


### PR DESCRIPTION
# Breaking change!
## This pr switches to custom cairo-vm, where i removed part of function which saved user input into output.

### This change is essential to prevent user input from appearing in the proof output, as such a scenario undermines the core principles of zero-knowledge proofs, including scalability and privacy. I consulted with the Cairo VM developers regarding this design, where input data is included in the output, and they clarified that it was implemented solely for testing purposes. They also assured me that this design will be updated in the future. This change ensures that the behavior of cairo1-run aligns with that of cairo0, maintaining consistency between those two.